### PR TITLE
Correct minor typo; word `and` spelled wrongly as `annd`

### DIFF
--- a/index.html
+++ b/index.html
@@ -1136,7 +1136,7 @@
               </div>
               <div class="answerWrapper" js-data="faqAnswer">
                 <p>
-                  Open Collective Foundation annd the Open Collective platform
+                  Open Collective Foundation and the Open Collective platform
                   offer unique features that you won't find anywhere else.
                   <a
                     href="https://docs.opencollective.foundation/about/what-we-offer#how-were-different"


### PR DESCRIPTION
Correct typo of word `and` which I noticed while reading this website. 😄 