### PR TITLE
Provide a way to link into docs frame

### DIFF
--- a/src/assets/scripts/goToDocsUrl.js
+++ b/src/assets/scripts/goToDocsUrl.js
@@ -1,0 +1,20 @@
+const DOCS_URL_KEY = 'docs';
+
+function goToDocsUrl() {
+  const qs = new URLSearchParams(location.search);
+  const maybeDocsPath = qs.get(DOCS_URL_KEY);
+
+  if (!maybeDocsPath) {
+    return;
+  }
+
+  const docsFrame = document.getElementById('docs-frame');
+  docsFrame.src += maybeDocsPath;
+
+  // Otherwise scroll jumps up
+  setTimeout(() => {
+    docsFrame.scrollIntoView();
+  }, 500);
+}
+
+goToDocsUrl();

--- a/src/home/docs.ejs
+++ b/src/home/docs.ejs
@@ -2,7 +2,6 @@
 title: Docs
 position: 6
 ---
-
   <div class="heading-container">
     <h2>Resources and documentation</h2>
   </div>
@@ -10,6 +9,8 @@ position: 6
 <div class="docs-container">
 
   <iframe
+    id="docs-frame"
+    name="docs"
     title="Open Collective Foundation Docs"
     class="docs-frame"
     src="https://docs.opencollective.foundation/"
@@ -17,3 +18,5 @@ position: 6
     loading="lazy"
   ></iframe>
 </div>
+
+<script src="/assets/scripts/goToDocsUrl.js"></script>


### PR DESCRIPTION
Add url param `?docs=` which will append to the docs frame url. For instance `?docs=getting-started/how-to-apply`

Resolves https://github.com/opencollective/foundation-website/issues/90